### PR TITLE
BaSP-TG-87: Hotfix - Employee projects not being automatically updated after Assign Employee to Project

### DIFF
--- a/src/controllers/projects.js
+++ b/src/controllers/projects.js
@@ -183,6 +183,16 @@ const addEmployee = async (req, res) => {
       { new: true },
     );
 
+    await Employees.findByIdAndUpdate(
+      { _id: newEmployee.employeeId },
+      {
+        $push: {
+          projects: id,
+        },
+      },
+      { new: true },
+    );
+
     return res.status(201).json({
       message: 'Employee has been added successfully',
       data: addEmployeedProject,


### PR DESCRIPTION
**Ticket**: https://trello.com/c/LidMDavI/87-populate-project-on-employee-server

**Bug**: When you use 'Assign Employee' feature of Projects to add a new Employee to a project, the list of Projects from that Employee is not automatically updated after the request is made. You have to do it manually with a new PUT request on Employees.