### PR TITLE
BaSP-TG-106: add admin role to timesheets routes

### DIFF
--- a/src/routes/timesheets.js
+++ b/src/routes/timesheets.js
@@ -8,10 +8,10 @@ const router = express.Router();
 router
   .put('/', timesheetsControllers.missingId)
   .delete('/', timesheetsControllers.missingId)
-  .post('/', checkAuth(['EMPLOYEE']), timesheetsValidation.validateCreation, timesheetsControllers.createTimesheet)
+  .post('/', checkAuth(['EMPLOYEE', 'ADMIN']), timesheetsValidation.validateCreation, timesheetsControllers.createTimesheet)
   .get('/', checkAuth(['ADMIN', 'EMPLOYEE']), timesheetsControllers.getAllTimesheets)
   .get('/:id', checkAuth(['ADMIN', 'EMPLOYEE']), timesheetsControllers.getTimesheetById)
-  .put('/:id', checkAuth(['EMPLOYEE']), timesheetsValidation.validateUpdate, timesheetsControllers.editTimesheetById)
-  .delete('/:id', checkAuth(['EMPLOYEE']), timesheetsControllers.deleteTimesheetById);
+  .put('/:id', checkAuth(['EMPLOYEE', 'ADMIN']), timesheetsValidation.validateUpdate, timesheetsControllers.editTimesheetById)
+  .delete('/:id', checkAuth(['EMPLOYEE', 'ADMIN']), timesheetsControllers.deleteTimesheetById);
 
 export default router;


### PR DESCRIPTION
We needed to add the admin role to the timesheet paths. So we can modify a timesheet being an administrator.

Contributors: @DamianPalavecino @mara666 