### PR TITLE
BaSP-TG-114: Fix Employee access to Get by ID, Delete and Put actions

### DIFF
--- a/src/routes/employees.js
+++ b/src/routes/employees.js
@@ -6,10 +6,10 @@ import employeeValidations from '../validations/employees';
 const router = express.Router();
 
 router
-  .put('/:id', checkAuth(['ADMIN']), employeeValidations.validateEdition, employeeControllers.editEmployee)
-  .delete('/:id', checkAuth(['ADMIN']), employeeControllers.deleteEmployee)
+  .put('/:id', checkAuth(['EMPLOYEE', 'ADMIN']), employeeValidations.validateEdition, employeeControllers.editEmployee)
+  .delete('/:id', checkAuth(['EMPLOYEE', 'ADMIN']), employeeControllers.deleteEmployee)
   .get('/', checkAuth(['ADMIN']), employeeControllers.getAllEmployees)
-  .get('/:id', checkAuth(['ADMIN']), employeeControllers.getEmployeeById)
+  .get('/:id', checkAuth(['EMPLOYEE', 'ADMIN']), employeeControllers.getEmployeeById)
   .post('/', employeeValidations.validateCreation, employeeControllers.createEmployee);
 
 export default router;


### PR DESCRIPTION
Ticket: https://trello.com/c/Yc89l7fq/114-hotfix-employee-auth-rights

You can’t get use getById as Employee so he/she can’t access to his/her projects nor timesheets. Also, an employee can’t create timesheets as his/her projects can’t be loaded.

Solution: Fix checkAuth() parameters in Employees routes.